### PR TITLE
remove center widget

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-nullsafety.0"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -87,7 +87,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:

--- a/lib/flutter_badge.dart
+++ b/lib/flutter_badge.dart
@@ -65,35 +65,33 @@ class FlutterBadgeState extends State<FlutterBadge> {
         ? null
         : RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(widget.borderRadius));
-    return Center(
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          widget.icon,
-          BadgePositioned(
-            position: widget.position ?? BadgePosition.topRight(),
-            child: Material(
-                type: widget.itemCount < 10
-                    ? MaterialType.circle
-                    : MaterialType.card,
-                elevation: 2.0,
-                shape: border,
-                color: widget.badgeColor,
-                child: Padding(
-                  padding: widget.contentPadding,
-                  child: Text(
-                    widget.itemCount.toString(),
-                    style: widget.textStyle ??
-                        TextStyle(
-                          fontSize: widget.textSize,
-                          color: widget.badgeTextColor,
-                          fontWeight: FontWeight.bold,
-                        ),
-                  ),
-                )),
-          ),
-        ],
-      ),
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        widget.icon,
+        BadgePositioned(
+          position: widget.position ?? BadgePosition.topRight(),
+          child: Material(
+              type: widget.itemCount < 10
+                  ? MaterialType.circle
+                  : MaterialType.card,
+              elevation: 2.0,
+              shape: border,
+              color: widget.badgeColor,
+              child: Padding(
+                padding: widget.contentPadding,
+                child: Text(
+                  widget.itemCount.toString(),
+                  style: widget.textStyle ??
+                      TextStyle(
+                        fontSize: widget.textSize,
+                        color: widget.badgeTextColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              )),
+        ),
+      ],
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Hi, thanks for the package.

This PR removes the `Center` widget as this makes it so icon/widget the badge is applied to is _always_ centered. Removing this allows the consuming app to handle the positioning.